### PR TITLE
Implement multi-page Jumpkat website

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Jumpkat</title>
+  <title>Blog - Jumpkat</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <script src="script.js" defer></script>
@@ -20,9 +20,8 @@
     <button class="theme-toggle" onclick="toggleTheme()">Flip</button>
   </header>
   <main>
-    <h1>Welcome to Jumpkat</h1>
-    <p>Unity solutions and indie mobile games from Newcastle upon Tyne.</p>
-    <p>We are preparing for our grand opening!</p>
+    <h1>Blog</h1>
+    <p><a href="blog/welcome.html">Welcome to the Blog</a></p>
   </main>
   <footer>
     <img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat">

--- a/blog/welcome.html
+++ b/blog/welcome.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Welcome to the Blog</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js" defer></script>
+  <script async defer data-domain="jumpkat.com" src="https://plausible.io/js/plausible.js"></script>
+</head>
+<body>
+  <canvas id="particles"></canvas>
+  <header>
+    <a href="../index.html"><img src="../images/jumping-cat.svg" alt="Jumpkat" height="40"></a>
+    <nav>
+      <a href="../games.html">Games</a>
+      <a href="../blog.html">Blog</a>
+      <a href="../contact.html">Contact</a>
+    </nav>
+    <button class="theme-toggle" onclick="toggleTheme()">Flip</button>
+  </header>
+  <main>
+<h1>Welcome to the Blog</h1>
+<p>This is the first post on Jumpkat where we'll share updates about game development, music and more.</p>
+<div id="comments"></div>
+<textarea id="comment-input" placeholder="Add a comment"></textarea>
+<button onclick="addComment()">Post</button>
+</main>
+  <footer>
+    <img src="../images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat">
+    <p>Jumpkat established 2023. All rights reserved.</p>
+    <p>Check out Kuba's album while you're here :)</p>
+    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/album/49JnWym3X5izUPFvnquMEY?utm_source=generator" width="100%" height="352" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+  </footer>
+<script>
+const page='welcome';
+function loadComments(){
+ const c=JSON.parse(localStorage.getItem('c_'+page)||'[]');
+ document.getElementById('comments').innerHTML=c.map(x=>'<p>'+x+'</p>').join('');
+}
+function addComment(){
+ const inp=document.getElementById('comment-input');
+ const c=JSON.parse(localStorage.getItem('c_'+page)||'[]');
+ c.push(inp.value);
+ localStorage.setItem('c_'+page,JSON.stringify(c));
+ inp.value='';
+ loadComments();
+}
+document.addEventListener('DOMContentLoaded',loadComments);
+</script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Jumpkat</title>
+  <title>Contact - Jumpkat</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <script src="script.js" defer></script>
@@ -20,15 +20,20 @@
     <button class="theme-toggle" onclick="toggleTheme()">Flip</button>
   </header>
   <main>
-    <h1>Welcome to Jumpkat</h1>
-    <p>Unity solutions and indie mobile games from Newcastle upon Tyne.</p>
-    <p>We are preparing for our grand opening!</p>
+    <h1>Contact</h1>
+    <p>Reach out using the form below or email kuba@jumpkat.com</p>
+    <form action="mailto:kuba@jumpkat.com" method="post" enctype="text/plain">
+      <p><input type="text" name="name" placeholder="Your Name"></p>
+      <p><input type="email" name="email" placeholder="Your Email"></p>
+      <p><textarea name="message" rows="5" cols="40" placeholder="Message"></textarea></p>
+      <p><button type="submit">Send</button></p>
+    </form>
+    <p>Email: kuba@jumpkat.com</p>
+    <p>Phone: 123-456-7890</p>
   </main>
   <footer>
     <img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat">
     <p>Jumpkat established 2023. All rights reserved.</p>
-    <p>Check out Kuba's album while you're here :)</p>
-    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/album/49JnWym3X5izUPFvnquMEY?utm_source=generator" width="100%" height="352" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
   </footer>
 </body>
 </html>

--- a/games.html
+++ b/games.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Jumpkat</title>
+  <title>Games - Jumpkat</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <script src="script.js" defer></script>
@@ -20,15 +20,13 @@
     <button class="theme-toggle" onclick="toggleTheme()">Flip</button>
   </header>
   <main>
-    <h1>Welcome to Jumpkat</h1>
-    <p>Unity solutions and indie mobile games from Newcastle upon Tyne.</p>
-    <p>We are preparing for our grand opening!</p>
+    <h1>Games</h1>
+    <p>Currently developing <strong>Negative Space</strong> for iPhone, WebGL and Android.</p>
+    <p><a href="play.html" class="game-button">Play Games</a></p>
   </main>
   <footer>
     <img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat">
     <p>Jumpkat established 2023. All rights reserved.</p>
-    <p>Check out Kuba's album while you're here :)</p>
-    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/album/49JnWym3X5izUPFvnquMEY?utm_source=generator" width="100%" height="352" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
   </footer>
 </body>
 </html>

--- a/juggle.html
+++ b/juggle.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Juggle Cats</title>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
+<script async defer data-domain="jumpkat.com" src="https://plausible.io/js/plausible.js"></script>
+<style>canvas{background:var(--text-color);}</style>
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header>
+<a href="index.html"><img src="images/jumping-cat.svg" alt="Jumpkat" height="40"></a>
+<nav>
+<a href="games.html">Games</a>
+<a href="blog.html">Blog</a>
+<a href="contact.html">Contact</a>
+</nav>
+<button class="theme-toggle" onclick="toggleTheme()">Flip</button>
+</header>
+<main>
+<h1>Juggle Cats</h1>
+<canvas id="game" width="400" height="300"></canvas>
+<p>Score: <span id="score">0</span></p>
+</main>
+<footer><img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat"></footer>
+<script>
+const c=document.getElementById('game');
+const ctx=c.getContext('2d');
+let balls=[{x:100,y:280,vy:0},{x:200,y:280,vy:0},{x:300,y:280,vy:0}],score=0;
+function draw(){
+ ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--bg-color');
+ ctx.fillRect(0,0,400,300);
+ ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--text-color');
+ balls.forEach(b=>ctx.beginPath(),ctx.arc(b.x,b.y,15,0,Math.PI*2),ctx.fill());
+}
+function update(){
+ balls.forEach(b=>{b.vy+=0.2;b.y+=b.vy;if(b.y>285){b.y=285;b.vy=0;}});
+ if(balls.every(b=>b.y>=285)){score=0;document.getElementById('score').textContent=score;}
+ draw();
+ requestAnimationFrame(update);
+}
+c.addEventListener('click',e=>{
+ const rect=c.getBoundingClientRect();
+ const x=e.clientX-rect.left,y=e.clientY-rect.top;
+ balls.forEach(b=>{const dx=x-b.x,dy=y-b.y;if(Math.sqrt(dx*dx+dy*dy)<15){b.vy=-5;score++;document.getElementById('score').textContent=score;}});
+});
+update();
+</script>
+</body>
+</html>

--- a/play.html
+++ b/play.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Jumpkat</title>
+  <title>Select Game - Jumpkat</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <script src="script.js" defer></script>
@@ -20,15 +20,15 @@
     <button class="theme-toggle" onclick="toggleTheme()">Flip</button>
   </header>
   <main>
-    <h1>Welcome to Jumpkat</h1>
-    <p>Unity solutions and indie mobile games from Newcastle upon Tyne.</p>
-    <p>We are preparing for our grand opening!</p>
+    <h1>Select a Game</h1>
+    <div class="game-button"><a href="pong.html">Pong<br><img src="images/album-cover.jpg" alt="Pong"></a></div>
+    <div class="game-button"><a href="snake.html">Snake<br><img src="images/album-cover.jpg" alt="Snake"></a></div>
+    <div class="game-button"><a href="tower.html">Tower Builder<br><img src="images/album-cover.jpg" alt="Tower"></a></div>
+    <div class="game-button"><a href="juggle.html">Juggle Cats<br><img src="images/album-cover.jpg" alt="Juggle"></a></div>
   </main>
   <footer>
     <img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat">
     <p>Jumpkat established 2023. All rights reserved.</p>
-    <p>Check out Kuba's album while you're here :)</p>
-    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/album/49JnWym3X5izUPFvnquMEY?utm_source=generator" width="100%" height="352" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
   </footer>
 </body>
 </html>

--- a/pong.html
+++ b/pong.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pong</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+  <script async defer data-domain="jumpkat.com" src="https://plausible.io/js/plausible.js"></script>
+  <style>
+    canvas{background:var(--text-color);}
+  </style>
+</head>
+<body>
+  <canvas id="particles"></canvas>
+  <header>
+    <a href="index.html"><img src="images/jumping-cat.svg" alt="Jumpkat" height="40"></a>
+    <nav>
+      <a href="games.html">Games</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <button class="theme-toggle" onclick="toggleTheme()">Flip</button>
+  </header>
+  <main>
+    <h1>Pong</h1>
+    <canvas id="game" width="400" height="300"></canvas>
+  </main>
+  <footer>
+    <img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat">
+  </footer>
+<script>
+const canvas=document.getElementById('game');
+const ctx=canvas.getContext('2d');
+let p1=150,p2=150,ball={x:200,y:150,vx:2,vy:2};
+function draw(){
+  ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--bg-color');
+  ctx.fillRect(0,0,400,300);
+  ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--text-color');
+  ctx.fillRect(10,p1,10,50);
+  ctx.fillRect(380,p2,10,50);
+  ctx.fillRect(ball.x,ball.y,10,10);
+}
+function update(){
+  ball.x+=ball.vx;ball.y+=ball.vy;
+  if(ball.y<=0||ball.y>=290)ball.vy*=-1;
+  if(ball.x<=20&&ball.y>p1&&ball.y<p1+50)ball.vx*=-1;
+  if(ball.x>=370&&ball.y>p2&&ball.y<p2+50)ball.vx*=-1;
+  if(ball.x<0||ball.x>400){ball.x=200;ball.y=150;}
+  draw();
+  requestAnimationFrame(update);
+}
+document.addEventListener('keydown',e=>{
+  if(e.key==='w')p1-=5;
+  if(e.key==='s')p1+=5;
+  if(e.key==='ArrowUp')p2-=5;
+  if(e.key==='ArrowDown')p2+=5;
+});
+update();
+</script>
+</body>
+</html>

--- a/posts/welcome.md
+++ b/posts/welcome.md
@@ -1,0 +1,3 @@
+# Welcome to the Blog
+
+This is the first post on Jumpkat where we'll share updates about game development, music and more.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,56 @@
+function toggleTheme(){
+  const root=document.documentElement;
+  const current=root.style.getPropertyValue('--bg-color')||getComputedStyle(root).getPropertyValue('--bg-color');
+  if(current.trim()==='#000'){
+    root.style.setProperty('--bg-color','#fff');
+    root.style.setProperty('--text-color','#000');
+    localStorage.setItem('theme','light');
+  }else{
+    root.style.setProperty('--bg-color','#000');
+    root.style.setProperty('--text-color','#fff');
+    localStorage.setItem('theme','dark');
+  }
+}
+
+function loadTheme(){
+  const saved=localStorage.getItem('theme');
+  if(saved==='light'){
+    document.documentElement.style.setProperty('--bg-color','#fff');
+    document.documentElement.style.setProperty('--text-color','#000');
+  }
+}
+
+function particles(){
+  const canvas=document.getElementById('particles');
+  if(!canvas)return;
+  const ctx=canvas.getContext('2d');
+  let width,height,particles=[];
+  function resize(){
+    width=canvas.width=window.innerWidth;
+    height=canvas.height=window.innerHeight;
+  }
+  window.addEventListener('resize',resize);
+  resize();
+  function addParticle(){
+    particles.push({x:Math.random()*width,y:-10,s:2+Math.random()*3,v:0.5+Math.random(),life:100+Math.random()*100});
+  }
+  function update(){
+    ctx.clearRect(0,0,width,height);
+    if(particles.length<100)addParticle();
+    particles.forEach(p=>{
+      p.y+=p.v;
+      p.life--;
+      ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--text-color');
+      ctx.globalAlpha=Math.max(p.life/200,0);
+      ctx.fillRect(p.x,p.y,p.s,p.s);
+    });
+    particles=particles.filter(p=>p.life>0);
+    requestAnimationFrame(update);
+  }
+  update();
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+  loadTheme();
+  particles();
+});

--- a/snake.html
+++ b/snake.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Snake</title>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
+<script async defer data-domain="jumpkat.com" src="https://plausible.io/js/plausible.js"></script>
+<style>canvas{background:var(--text-color);}</style>
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header>
+<a href="index.html"><img src="images/jumping-cat.svg" alt="Jumpkat" height="40"></a>
+<nav>
+<a href="games.html">Games</a>
+<a href="blog.html">Blog</a>
+<a href="contact.html">Contact</a>
+</nav>
+<button class="theme-toggle" onclick="toggleTheme()">Flip</button>
+</header>
+<main>
+<h1>Snake</h1>
+<canvas id="game" width="400" height="400"></canvas>
+</main>
+<footer><img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat"></footer>
+<script>
+const c=document.getElementById('game');
+const x=c.getContext('2d');
+let snake=[[10,10]],dir=[1,0],food=[15,15];
+function draw(){
+ x.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--bg-color');
+ x.fillRect(0,0,400,400);
+ x.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--text-color');
+ snake.forEach(([sx,sy])=>x.fillRect(sx*20,sy*20,18,18));
+ x.fillRect(food[0]*20,food[1]*20,18,18);
+}
+function step(){
+ const head=[snake[0][0]+dir[0],snake[0][1]+dir[1]];
+ if(head[0]<0||head[0]>=20||head[1]<0||head[1]>=20||snake.some(s=>s[0]==head[0]&&s[1]==head[1])){
+  snake=[[10,10]];dir=[1,0];
+ }
+ snake.unshift(head);
+ if(head[0]==food[0]&&head[1]==food[1]){
+  food=[Math.floor(Math.random()*20),Math.floor(Math.random()*20)];
+ }else{snake.pop();}
+ draw();
+}
+document.addEventListener('keydown',e=>{
+ if(e.key==='ArrowUp'&&dir[1]!=1)dir=[0,-1];
+ if(e.key==='ArrowDown'&&dir[1]!=-1)dir=[0,1];
+ if(e.key==='ArrowLeft'&&dir[0]!=1)dir=[-1,0];
+ if(e.key==='ArrowRight'&&dir[0]!=-1)dir=[1,0];
+});
+setInterval(step,200);
+</script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,74 @@
+:root {
+  --bg-color: #000;
+  --text-color: #fff;
+}
+
+body {
+  margin: 0;
+  font-family: 'Press Start 2P', monospace;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  text-align: center;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+}
+
+nav a {
+  color: var(--text-color);
+  margin: 0 10px;
+  text-decoration: none;
+}
+
+button.theme-toggle {
+  background: none;
+  border: 1px solid var(--text-color);
+  color: var(--text-color);
+  padding: 5px 10px;
+  cursor: pointer;
+  font-family: 'Press Start 2P', monospace;
+}
+
+footer {
+  margin-top: 40px;
+}
+
+.footer-cat {
+  width: 150px;
+  height: 150px;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+
+main {
+  padding: 20px;
+}
+
+canvas#particles {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.game-button {
+  display: inline-block;
+  margin: 20px;
+  padding: 10px;
+  border: 1px solid var(--text-color);
+  cursor: pointer;
+}
+
+.game-button img {
+  width: 200px;
+  height: 150px;
+  display: block;
+}

--- a/tower.html
+++ b/tower.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Tower Builder</title>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<script src="script.js" defer></script>
+<script async defer data-domain="jumpkat.com" src="https://plausible.io/js/plausible.js"></script>
+<style>canvas{background:var(--text-color);}</style>
+</head>
+<body>
+<canvas id="particles"></canvas>
+<header>
+<a href="index.html"><img src="images/jumping-cat.svg" alt="Jumpkat" height="40"></a>
+<nav>
+<a href="games.html">Games</a>
+<a href="blog.html">Blog</a>
+<a href="contact.html">Contact</a>
+</nav>
+<button class="theme-toggle" onclick="toggleTheme()">Flip</button>
+</header>
+<main>
+<h1>Tower Builder</h1>
+<canvas id="game" width="400" height="400"></canvas>
+<p>Press space to drop blocks</p>
+</main>
+<footer><img src="images/935CF301-8553-44E6-98FD-A0E992BEBD36.png" alt="Jumping Cat" class="footer-cat"></footer>
+<script>
+const c=document.getElementById('game');
+const ctx=c.getContext('2d');
+let armX=0,dir=1,blocks=[],current={x:0,y:20};
+function draw(){
+ ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--bg-color');
+ ctx.fillRect(0,0,400,400);
+ ctx.fillStyle=getComputedStyle(document.documentElement).getPropertyValue('--text-color');
+ ctx.fillRect(armX,0,40,20);
+ blocks.forEach(b=>ctx.fillRect(b.x,b.y,40,20));
+ if(current)ctx.fillRect(current.x,current.y,40,20);
+}
+function update(){
+ armX+=dir*2;
+ if(armX<0||armX>360)dir*=-1;
+ if(current){current.x=armX;current.y+=2;if(current.y>=380||blocks.some(b=>current.y+20>=b.y&&current.x<b.x+40&&current.x+40>b.x)){blocks.push({x:current.x,y:current.y-2});current=null;}}
+ draw();
+ requestAnimationFrame(update);
+}
+document.addEventListener('keydown',e=>{if(e.code==='Space'&&!current){current={x:armX,y:0};}});
+update();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyled site with 8-bit theme and color flip support
- added navigation with Games, Blog and Contact pages
- created mini-games: Pong, Snake, Tower Builder and Juggle Cats
- initial blog with comment support and first post
- simple contact form with mailto link
- particle overlay and Plausible analytics on each page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68500d4fe280832d876ddf1f2a7807d2